### PR TITLE
Change to JSON params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.1.1 - 2020-03-15
+
+- Change snippet parameters to JSON query string parameter (e.g., `params={"foo":"bar"}`) from serialized query string parameter (e.g.,`params[foo]=bar`).
+
 ## 1.1.0 - 2020-03-14
 
 - Add snippet parameters.

--- a/lib/jahuty/service/get.rb
+++ b/lib/jahuty/service/get.rb
@@ -9,7 +9,9 @@ module Jahuty
     end
 
     def call(id, params = {})
-      response = @connection.get("snippets/#{id}", { params: params })
+      options = { params: params.to_json } if !params.empty?
+
+      response = @connection.get("snippets/#{id}", options || {})
 
       payload = JSON.parse(response.body, symbolize_names: true)
 


### PR DESCRIPTION
Let's change snippet parameters to a URL-encoded JSON string. This avoids the complications of how different languages serialize the same array into query string parameters.