### PR TITLE
2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change `Snippet.get` to `Snippet.render`.
 - Change optional second argument of `Snippet.render` from `params` hash to options hash with `params` key.
 - Change `Data::Snippet` to `Data::Render`.
+- Remove `id` attribute from `Data::Render`.
 
 ## 1.1.2 - 2020-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change `service/get` to `service/render`.
 - Change `Snippet.get` to `Snippet.render`.
+- Change optional second argument of `Snippet.render` from `params` hash to options hash with `params` key.
 
 ## 1.1.2 - 2020-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 2.0.0 - 2020-07-04
 
 - Change `service/get` to `service/render`.
+- Change `Snippet.get` to `Snippet.render`.
 
 ## 1.1.2 - 2020-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change optional second argument of `Snippet.render` from `params` hash to options hash with `params` key.
 - Change `Data::Snippet` to `Data::Render`.
 - Remove `id` attribute from `Data::Render`.
+- Change API endpoint to `snippets/:id/render`.
 
 ## 1.1.2 - 2020-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.0 - 2020-07-04
+
+- Change `service/get` to `service/render`.
+
 ## 1.1.2 - 2020-07-04
 
 - Change the Faraday gem from `~> 0.1` to `~> 1.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 2.0.0 - 2020-07-04
 
-- Change `service/get` to `service/render`.
+- Change `Service::Get` to `Service::Render`.
 - Change `Snippet.get` to `Snippet.render`.
 - Change optional second argument of `Snippet.render` from `params` hash to options hash with `params` key.
+- Change `Data::Snippet` to `Data::Render`.
 
 ## 1.1.2 - 2020-07-04
 

--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ With the API key set, you can use the `Snippet.render` method to render a snippe
 require "jahuty"
 
 # retrieve the snippet
-snippet = Snippet.render YOUR_SNIPPET_ID
+render = Snippet.render YOUR_SNIPPET_ID
 
 # convert it to a string
-snippet.to_s
+render.to_s
 
 # or, access its attributes
-snippet.id
-snippet.content
+render.id
+render.content
 ```
 
 In an HTML view:

--- a/README.md
+++ b/README.md
@@ -65,28 +65,18 @@ Jahuty.key = "YOUR_API_KEY"
 
 ## Parameters
 
-You can [pass parameters](https://www.jahuty.com/docs/passing-a-parameter) into your snippet with an optional second argument:
+You can [pass parameters](https://www.jahuty.com/docs/passing-a-parameter) into your snippet using the `params` key of the options hash:
 
 ```ruby
 require "jahuty"
 
-Snippet.render(YOUR_SNIPPET_ID, {
-  foo:   "bar",
-  baz:   ["qux", "quux"],
-  corge: {
-    grault: {
-      garply: "waldo"
-    }
-  }
-});
+Snippet.render(YOUR_SNIPPET_ID, params: { foo: "bar" });
 ```
 
 The parameters above would be equivalent to [assigning the variables](https://www.jahuty.com/docs/assigning-a-variable) below in your snippet:
 
 ```html
 {% assign foo = "bar" %}
-{% assign baz = ["qux", "quux"] %}
-{% assign corge.grault.garply = "waldo" %}
 ```
 
 ## Errors

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ render = Snippet.render YOUR_SNIPPET_ID
 render.to_s
 
 # or, access its attributes
-render.id
 render.content
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # jahuty-ruby
-Welcome [Jahuty's](https://www.jahuty.com) Ruby SDK!
+Welcome to [Jahuty's](https://www.jahuty.com) Ruby SDK!
 
 ## Installation
 
@@ -7,7 +7,7 @@ This library requires [Ruby 2.3+](https://www.ruby-lang.org/en/downloads/release
 
 It is multi-platform, and we strive to make it run equally well on Windows, Linux, and OSX.
 
-Add this line to your application's `Gemfile`, where `x` is the latest major version number:
+Add this line to your application's `Gemfile`:
 
 ```ruby
 gem "jahuty", "~> 1.0"
@@ -29,15 +29,13 @@ require "jahuty"
 Jahuty.key = "YOUR_API_KEY"
 ```
 
-With the API key set, you can use the `get()` method to retrieve a snippet:
-
-Then, use the `.get` method to fetch a snippet:
+With the API key set, you can use the `Snippet.render` method to render a snippet:
 
 ```ruby
 require "jahuty"
 
 # retrieve the snippet
-snippet = Snippet.get YOUR_SNIPPET_ID
+snippet = Snippet.render YOUR_SNIPPET_ID
 
 # convert it to a string
 snippet.to_s
@@ -61,7 +59,7 @@ Jahuty.key = "YOUR_API_KEY"
     <title>Awesome example</title>
 </head>
 <body>
-    <%= Snippet.get YOUR_SNIPPET_ID %>
+    <%= Snippet.render YOUR_SNIPPET_ID %>
 </body>
 ```
 
@@ -72,7 +70,7 @@ You can [pass parameters](https://www.jahuty.com/docs/passing-a-parameter) into 
 ```ruby
 require "jahuty"
 
-Snippet.get(YOUR_SNIPPET_ID, {
+Snippet.render(YOUR_SNIPPET_ID, {
   foo:   "bar",
   baz:   ["qux", "quux"],
   corge: {
@@ -93,13 +91,13 @@ The parameters above would be equivalent to [assigning the variables](https://ww
 
 ## Errors
 
-If you don't set your API key before calling `Snippet.get`, a `StandardError` will be raised. If an error occurs with [Jahuty's API](https://www.jahuty.com/docs/api), a `NotOk` exception will be raised:
+If you don't set your API key before calling `Snippet.render`, a `StandardError` will be raised. If an error occurs with [Jahuty's API](https://www.jahuty.com/docs/api), a `NotOk` exception will be raised:
 
 ```ruby
 require "jahuty"
 
 begin
-  Snippet.get YOUR_SNIPPET_ID
+  Snippet.render YOUR_SNIPPET_ID
 rescue StandardError => e
   # hmm, did you set the API key first?
 rescue Jahuty::Exception::NotOk => e

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It is multi-platform, and we strive to make it run equally well on Windows, Linu
 Add this line to your application's `Gemfile`:
 
 ```ruby
-gem "jahuty", "~> 1.0"
+gem "jahuty", "~> 2.0"
 ```
 
 And then execute:

--- a/lib/jahuty.rb
+++ b/lib/jahuty.rb
@@ -8,7 +8,7 @@ require "jahuty/data/snippet"
 require "jahuty/exception/not_ok"
 
 require "jahuty/service/connect"
-require "jahuty/service/get"
+require "jahuty/service/render"
 
 module Jahuty
   @key

--- a/lib/jahuty.rb
+++ b/lib/jahuty.rb
@@ -3,7 +3,7 @@ require "jahuty/version"
 require "jahuty/snippet"
 
 require "jahuty/data/problem"
-require "jahuty/data/snippet"
+require "jahuty/data/render"
 
 require "jahuty/exception/not_ok"
 

--- a/lib/jahuty/data/render.rb
+++ b/lib/jahuty/data/render.rb
@@ -1,6 +1,6 @@
 module Jahuty
   module Data
-    class Snippet
+    class Render
       attr_accessor :id, :content
 
       def initialize(id, content)
@@ -12,7 +12,7 @@ module Jahuty
         raise ArgumentError.new "Key :id does not exist" if !data.key?(:id)
         raise ArgumentError.new "Key :content does not exist" if !data.key?(:content)
 
-        Snippet.new(data[:id], data[:content])
+        Render.new(data[:id], data[:content])
       end
 
       def to_s

--- a/lib/jahuty/data/render.rb
+++ b/lib/jahuty/data/render.rb
@@ -1,18 +1,16 @@
 module Jahuty
   module Data
     class Render
-      attr_accessor :id, :content
+      attr_accessor :content
 
-      def initialize(id, content)
-        @id      = id
+      def initialize(content)
         @content = content
       end
 
       def self.from(data)
-        raise ArgumentError.new "Key :id does not exist" if !data.key?(:id)
         raise ArgumentError.new "Key :content does not exist" if !data.key?(:content)
 
-        Render.new(data[:id], data[:content])
+        Render.new(data[:content])
       end
 
       def to_s

--- a/lib/jahuty/service/render.rb
+++ b/lib/jahuty/service/render.rb
@@ -11,7 +11,7 @@ module Jahuty
     def call(id, options = {})
       settings = { params: options[:params].to_json } unless options[:params].nil?
 
-      response = @connection.get("snippets/#{id}", settings || {})
+      response = @connection.get("snippets/#{id}/render", settings || {})
 
       payload = JSON.parse(response.body, symbolize_names: true)
 

--- a/lib/jahuty/service/render.rb
+++ b/lib/jahuty/service/render.rb
@@ -1,7 +1,7 @@
 require "json"
 
 module Jahuty
-  class Service::Get
+  class Service::Render
     @connection
 
     def initialize(connection)

--- a/lib/jahuty/service/render.rb
+++ b/lib/jahuty/service/render.rb
@@ -19,7 +19,7 @@ module Jahuty
         raise Exception::NotOk.new(Data::Problem.from(payload))
       end
 
-      return Data::Snippet.from(payload)
+      return Data::Render.from(payload)
     end
   end
 end

--- a/lib/jahuty/service/render.rb
+++ b/lib/jahuty/service/render.rb
@@ -8,10 +8,10 @@ module Jahuty
       @connection = connection
     end
 
-    def call(id, params = {})
-      options = { params: params.to_json } if !params.empty?
+    def call(id, options = {})
+      settings = { params: options[:params].to_json } unless options[:params].nil?
 
-      response = @connection.get("snippets/#{id}", options || {})
+      response = @connection.get("snippets/#{id}", settings || {})
 
       payload = JSON.parse(response.body, symbolize_names: true)
 

--- a/lib/jahuty/snippet.rb
+++ b/lib/jahuty/snippet.rb
@@ -6,7 +6,7 @@ module Jahuty
       def get(id, params = {})
         raise "API key not set. Did you use Jahuty.key?" unless Jahuty.key?
 
-        @get ||= Service::Get.new(Service::Connect.new.call(Jahuty.key))
+        @get ||= Service::Render.new(Service::Connect.new.call(Jahuty.key))
 
         @get.call(id, params)
       end

--- a/lib/jahuty/snippet.rb
+++ b/lib/jahuty/snippet.rb
@@ -3,7 +3,7 @@ module Jahuty
     @get
 
     class << self
-      def get(id, params = {})
+      def render(id, params = {})
         raise "API key not set. Did you use Jahuty.key?" unless Jahuty.key?
 
         @get ||= Service::Render.new(Service::Connect.new.call(Jahuty.key))

--- a/lib/jahuty/snippet.rb
+++ b/lib/jahuty/snippet.rb
@@ -3,12 +3,12 @@ module Jahuty
     @get
 
     class << self
-      def render(id, params = {})
+      def render(id, options = {})
         raise "API key not set. Did you use Jahuty.key?" unless Jahuty.key?
 
         @get ||= Service::Render.new(Service::Connect.new.call(Jahuty.key))
 
-        @get.call(id, params)
+        @get.call(id, options)
       end
     end
   end

--- a/lib/jahuty/version.rb
+++ b/lib/jahuty/version.rb
@@ -1,3 +1,3 @@
 module Jahuty
-  VERSION = "1.1.2"
+  VERSION = "2.0.0"
 end

--- a/spec/jahuty/data/render_spec.rb
+++ b/spec/jahuty/data/render_spec.rb
@@ -2,13 +2,7 @@ module Jahuty
   module Data
     RSpec.describe Render do
       describe ".from" do
-        let(:data) { { id: 1, content: "foo" } }
-
-        it "raises error if :id key does not exist" do
-          data.delete(:id)
-
-          expect{ Render.from(data) }.to raise_error(ArgumentError)
-        end
+        let(:data) { { content: "foo" } }
 
         it "raises error if :content key does not exist" do
           data.delete(:content)
@@ -19,7 +13,7 @@ module Jahuty
 
       describe "#to_s" do
         it "returns content" do
-          expect(Render.new(1, "foo").to_s).to eq("foo")
+          expect(Render.new("foo").to_s).to eq("foo")
         end
       end
     end

--- a/spec/jahuty/data/render_spec.rb
+++ b/spec/jahuty/data/render_spec.rb
@@ -1,25 +1,25 @@
 module Jahuty
   module Data
-    RSpec.describe Snippet do
+    RSpec.describe Render do
       describe ".from" do
         let(:data) { { id: 1, content: "foo" } }
 
         it "raises error if :id key does not exist" do
           data.delete(:id)
 
-          expect{ Snippet.from(data) }.to raise_error(ArgumentError)
+          expect{ Render.from(data) }.to raise_error(ArgumentError)
         end
 
         it "raises error if :content key does not exist" do
           data.delete(:content)
 
-          expect{ Snippet.from(data) }.to raise_error(ArgumentError)
+          expect{ Render.from(data) }.to raise_error(ArgumentError)
         end
       end
 
       describe "#to_s" do
         it "returns content" do
-          expect(Snippet.new(1, "foo").to_s).to eq("foo")
+          expect(Render.new(1, "foo").to_s).to eq("foo")
         end
       end
     end

--- a/spec/jahuty/service/render_spec.rb
+++ b/spec/jahuty/service/render_spec.rb
@@ -1,5 +1,5 @@
 module Jahuty
-  RSpec.describe Service::Get do
+  RSpec.describe Service::Render do
     describe "#call" do
       let(:response) do
         response = instance_double(::Faraday::Response)
@@ -20,7 +20,7 @@ module Jahuty
 
       let(:body) { '{ "status": 1, "type": "foo", "detail": "bar" }' }
 
-      subject { Service::Get.new(connection) }
+      subject { Service::Render.new(connection) }
 
       context "when the response's status code is 401" do
         let(:status) { 401 }

--- a/spec/jahuty/service/render_spec.rb
+++ b/spec/jahuty/service/render_spec.rb
@@ -51,7 +51,7 @@ module Jahuty
         let(:body)   { '{"id": 1, "content": "foo"}' }
 
         it "returns a snippet" do
-          expect(subject.call(1)).to be_instance_of(Data::Snippet)
+          expect(subject.call(1)).to be_instance_of(Data::Render)
         end
       end
     end

--- a/spec/jahuty/snippet_spec.rb
+++ b/spec/jahuty/snippet_spec.rb
@@ -5,7 +5,7 @@ module Jahuty
 
       it "returns content" do
         expect(Snippet.render(1)).to have_attributes({
-          id: 1, content: "This is my first snippet!"
+          content: "This is my first snippet!"
         })
       end
     end

--- a/spec/jahuty/snippet_spec.rb
+++ b/spec/jahuty/snippet_spec.rb
@@ -1,6 +1,6 @@
 module Jahuty
   RSpec.describe Snippet do
-    describe "::get" do
+    describe "::render" do
       before { Jahuty.key = 'kn2Kj5ijmT2pH6ZKqAQyNexUqKeRM4VG6DDgWN1lIcc' }
 
       it "returns content" do

--- a/spec/jahuty/snippet_spec.rb
+++ b/spec/jahuty/snippet_spec.rb
@@ -4,7 +4,7 @@ module Jahuty
       before { Jahuty.key = 'kn2Kj5ijmT2pH6ZKqAQyNexUqKeRM4VG6DDgWN1lIcc' }
 
       it "returns content" do
-        expect(Snippet.get(1)).to have_attributes({
+        expect(Snippet.render(1)).to have_attributes({
           id: 1, content: "This is my first snippet!"
         })
       end


### PR DESCRIPTION
Lots of breaking changes that follow our shift in logic from _retrieving_ snippets to _rendering_ them:

- Rename `Service::Get` to `Service::Render`.
- Rename `Snippet::get` to `Snippet::render`.
- Change the second argument of `Snippet.render` from a hash of params to an options hash with a `params` key.
- Rename `Data::Snippet` to `Data::Render`.
- Remove `id` attribute from Data\Render.
- Change API endpoint from `snippets/:id` to `snippets/:id/render`.