### PR TITLE
Update based url

### DIFF
--- a/lib/jahuty/service/connect.rb
+++ b/lib/jahuty/service/connect.rb
@@ -3,7 +3,7 @@ require "faraday"
 module Jahuty
   module Service
     class Connect
-      URL = "https://www.jahuty.com/api"
+      URL = "https://api.jahuty.com"
 
       HEADERS  = {
         "Accept":          "application/json;q=0.9,*/*;q=0.8",

--- a/lib/jahuty/version.rb
+++ b/lib/jahuty/version.rb
@@ -1,3 +1,3 @@
 module Jahuty
-  VERSION = "2.0.0"
+  VERSION = "2.1.0"
 end


### PR DESCRIPTION
Update the base url to match the API's move from `www.jahuty.com/api` to `api.jahuty.com`. 