### PR TITLE
Add caching

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,3 +10,6 @@ Metrics/BlockLength:
     - 'Rakefile'
     - '**/*.rake'
     - 'spec/**/*.rb'
+Metrics/ModuleLength:
+  Exclude:
+    - 'spec/**/*.rb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.1.0 - 2020-01-04
+
+- Add caching support for any cache implementation that supports `get/set` or `read/write` methods.
+- Default to using in-memory [mini-cache](https://github.com/derrickreimer/mini_cache) storage.
+
 ## 3.0.0 - 2020-12-30
 
 - Change from a static-based architecture (e.g., `Jahuty::Snippet.render(1)`) to an instance-based one (e.g., `jahuty.snippets.render(1)`) to make the library easier to develop, test, and use.

--- a/README.md
+++ b/README.md
@@ -18,11 +18,9 @@ gem 'jahuty', '~> 3.1'
 
 ## Usage
 
-Instantiate the client with your [API key](https://docs.jahuty.com/api#authentication) and use `snippets.render()` to render your snippet:
+Instantiate the client with your [API key](https://docs.jahuty.com/api#authentication) and use `snippets.render` to render your snippet:
 
 ```ruby
-require 'jahuty'
-
 jahuty = Jahuty::Client.new(api_key: 'YOUR_API_KEY')
 
 puts jahuty.snippets.render YOUR_SNIPPET_ID
@@ -74,10 +72,10 @@ The parameters above would be equivalent to [assigning the variable](https://doc
 
 ## Caching
 
-You can use caching to control how frequently this library requests content from Jahuty's API.
+You can use caching to control how frequently this library requests the latest content from Jahuty's API.
 
-* When content is frequently changing and low traffic (i.e., _development_, _testing_, or _staging_), you can use the default in-memory store to view content changes instantaneously.
-* When content is more stable and high traffic (i.e., _production_), you can configure persistent caching to reduce network requests and improve your application's response time.
+* When content is in _development_ (i.e., frequently changing and low traffic), you can use the default in-memory store to view content changes instantaneously with slower response times.
+* When content is in _production_ (i.e., more stable and high traffic), you can use persistent caching to update content less frequently and improve your application's response time.
 
 ### Caching in memory (default)
 
@@ -87,7 +85,7 @@ By default, this library uses an in-memory cache to avoid requesting the same re
 jahuty = Jahuty::Client.new(api_key: 'YOUR_API_KEY')
 
 # This call will send a synchronous API request; cache the result in memory;
-# and, returns the result to the caller.
+# and, return the result to the caller.
 render1 = jahuty.snippets.render YOUR_SNIPPET_ID
 
 # This call skips sending an API request and uses the cached value instead.
@@ -109,11 +107,11 @@ jahuty = new Jahuty::Client.new(
 )
 ```
 
-The persistent cache implementation you choose and configure is up to you. There are many libraries available, and most frameworks provide their own. At this time, we support any object which responds to `get(key)`/`set(key, value, expires_in:)` or `read(key)`/`write(key, value, expires_in:)` including [ActiveSupport::Cache::Store](https://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html#method-i-fetch). We aim to support as many cache implementations as we can, though, so if your implementation is missing, feel free to suggest support to `Jahuty::Cache::Manager` or let us know.
+The persistent cache implementation you choose and configure is up to you. There are many libraries available, and most frameworks provide their own. At this time, we support any object which responds to `get(key)`/`set(key, value, expires_in:)` or `read(key)`/`write(key, value, expires_in:)` including [ActiveSupport::Cache::Store](https://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html#method-i-fetch).
 
 ### Expiring
 
-There are three methods for configuring a render's `:expires_in`, the amount of time between when a render is stored and when it's considered stale. From lowest-to-highest precedence, they are:
+There are three methods for configuring this library's `:expires_in`, the amount of time between when a render is stored and when it's considered stale. From lowest-to-highest precedence, the methods are:
 
 1. configuring your caching implementation,
 1. configuring this library's default `:expires_in`, and
@@ -123,7 +121,7 @@ There are three methods for configuring a render's `:expires_in`, the amount of 
 
 You can usually configure your caching implementation with a default `:expires_in`. If no other `:expires_in` is configured, this library will defer to the caching implementation's default `:expires_in`.
 
-#### Configuring this library's default TTL
+#### Configuring this library's default `:expires_in`
 
 You can configure a default `:expires_in` for all of this library's renders by passing an integer number of seconds via the client's `:expires_in` configuration option:
 
@@ -137,12 +135,12 @@ jahuty = Jahuty::Client.new(
 
 If this library's default `:expires_in` is set, it will take precedence over the default `:expires_is` of the caching implementation.
 
-#### Configuring a render's TTL
+#### Configuring a render's `:expires_in`
 
-You can configure one render's `:expires_in` by passing an integer number of seconds via its `:expires_in` configuration option:
+You can configure a single render's `:expires_in` by passing an integer number of seconds via its `:expires_in` configuration option:
 
 ```ruby
-# Default to the caching implementation's :expires_in for all renders
+# Default to the caching implementation's :expires_in for all renders.
 jahuty = Jahuty::Client.new(api_key: 'YOUR_API_KEY', cache: cache)
 
 # Except, cache this render for 60 seconds.
@@ -157,11 +155,11 @@ You can disable caching, even the default in-memory caching, by passing an `:exp
 
 ```ruby
 # Disable all caching.
-jahuty = Jahuty::Client.new(api_key: 'YOUR_API_KEY', expires_in: 0)
+jahuty1 = Jahuty::Client.new(api_key: 'YOUR_API_KEY', expires_in: 0)
 
 # Disable caching for this render.
-jahuty = Jahuty::Client.new(api_key: 'YOUR_API_KEY')
-jahuty.snippets.render(1, expires_in: 0)
+jahuty2 = Jahuty::Client.new(api_key: 'YOUR_API_KEY', expires_in: 60)
+jahuty2.snippets.render(1, expires_in: 0)
 ```
 
 ## Errors
@@ -169,8 +167,6 @@ jahuty.snippets.render(1, expires_in: 0)
 If an error occurs with [Jahuty's API](https://docs.jahuty.com/api#errors), a `Jahuty::Exception::Error` will be raised:
 
 ```ruby
-require 'jahuty'
-
 begin
   jahuty = Jahuty::Client.new(api_key: 'YOUR_API_KEY')
   jahuty.snippets.render YOUR_SNIPPET_ID

--- a/jahuty.gemspec
+++ b/jahuty.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '~> 2.6'
 
   spec.add_dependency 'faraday', '~> 1.0'
+  spec.add_dependency 'mini_cache', '~> 1.1'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 12.3'

--- a/lib/jahuty.rb
+++ b/lib/jahuty.rb
@@ -7,6 +7,7 @@ require 'jahuty/action/show'
 
 require 'jahuty/api/client'
 
+require 'jahuty/cache/facade'
 require 'jahuty/cache/manager'
 
 require 'jahuty/exception/error'

--- a/lib/jahuty.rb
+++ b/lib/jahuty.rb
@@ -7,6 +7,8 @@ require 'jahuty/action/show'
 
 require 'jahuty/api/client'
 
+require 'jahuty/cache/manager'
+
 require 'jahuty/exception/error'
 
 require 'jahuty/request/base'

--- a/lib/jahuty/cache/facade.rb
+++ b/lib/jahuty/cache/facade.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Jahuty
+  module Cache
+    # Abstracts away the differences in cache implementation methods and
+    # argument lists.
+    class Facade
+      def initialize(cache)
+        @cache = cache
+      end
+
+      def delete(key)
+        if @cache.respond_to? :delete
+          @cache.delete key
+        elsif @cache.respond_to? :unset
+          @cache.unset key
+        else
+          raise NoMethodError, 'Cache must respond to :delete or :unset'
+        end
+      end
+
+      def read(key)
+        if @cache.respond_to? :read
+          @cache.read key
+        elsif @cache.respond_to? :get
+          @cache.get key
+        else
+          raise NoMethodError, 'Cache must respond to :read or :get'
+        end
+      end
+
+      def write(key, value, expires_in: nil)
+        if Object.const_defined?('::ActiveSupport::Cache::Store') &&
+           @cache.is_a?(::ActiveSupport::Cache::Store)
+          @cache.write key, value, expires_in: expires_in, race_condition_ttl: 10
+        elsif @cache.respond_to? :write
+          @cache.write key, value, expires_in: expires_in
+        elsif @cache.respond_to? :set
+          @cache.set key, value, expires_in: expires_in
+        else
+          raise NoMethodError, 'Cache must respond to :write or :set'
+        end
+      end
+    end
+  end
+end

--- a/lib/jahuty/cache/manager.rb
+++ b/lib/jahuty/cache/manager.rb
@@ -17,13 +17,27 @@ module Jahuty
 
         if value.nil?
           value = @client.request action
-          write key, value, expires_in: expires_in || @expires_in
+          if expires_in.nil? || expires_in > 0
+            write key, value, expires_in: expires_in || @expires_in
+          else
+            delete key
+          end
         end
 
         value
       end
 
       private
+
+      def delete(key)
+        if @cache.respond_to? :delete
+          @cache.delete key
+        elsif @cache.respond_to? :unset
+          @cache.unset key
+        else
+          raise NoMethodError, 'Cache should respond to :delete or :unset'
+        end
+      end
 
       def key(action)
         # Guard against caching unsupported actions.
@@ -37,12 +51,12 @@ module Jahuty
       end
 
       def read(key)
-        if @cache.respond_to?(:read)
-          @cache.read(key)
-        elsif @cache.respond_to?(:get)
-          @cache.get(key)
+        if @cache.respond_to? :read
+          @cache.read key
+        elsif @cache.respond_to? :get
+          @cache.get key
         else
-          raise ArgumentError, 'Cache not supported'
+          raise NoMethodError, 'Cache should respond to :read or :get'
         end
       end
 
@@ -53,13 +67,13 @@ module Jahuty
           # cache entry is used very frequently and is under heavy load.
           #
           # @see  https://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html#method-i-fetch
-          @cache.write(key, value, expires_in: expires_in, race_condition_ttl: 10)
-        elsif @cache.respond_to?(:write)
-          @cache.write(key, value, expires_in: expires_in)
-        elsif @cache.respond_to?(:set)
-          @cache.set(key, value, expires_in: expires_in)
+          @cache.write key, value, expires_in: expires_in, race_condition_ttl: 10
+        elsif @cache.respond_to? :write
+          @cache.write key, value, expires_in: expires_in
+        elsif @cache.respond_to? :set
+          @cache.set key, value, expires_in: expires_in
         else
-          raise ArgumentError, 'Cache not supported'
+          raise NoMethodError, 'Cache should respond to :write or :set'
         end
       end
     end

--- a/lib/jahuty/cache/manager.rb
+++ b/lib/jahuty/cache/manager.rb
@@ -2,26 +2,23 @@
 
 module Jahuty
   module Cache
-    # Abstracts away differences between cache implementations and fetches the
-    # requested action from the cache or API.
+    # Fetches the requested action from the cache or API.
     class Manager
       def initialize(cache:, client:, expires_in: nil)
         @client     = client
-        @cache      = cache
+        @cache      = Facade.new(cache)
         @expires_in = expires_in
       end
 
       def fetch(action, expires_in: nil)
         key   = key action
-        value = read key
+        value = @cache.read key
+
+        @cache.delete key unless value.nil? || cacheable(expires_in)
 
         if value.nil?
           value = @client.request action
-          if expires_in.nil? || expires_in > 0
-            write key, value, expires_in: expires_in || @expires_in
-          else
-            delete key
-          end
+          @cache.write key, value, expires_in: expires_in || @expires_in if cacheable(expires_in)
         end
 
         value
@@ -29,52 +26,21 @@ module Jahuty
 
       private
 
-      def delete(key)
-        if @cache.respond_to? :delete
-          @cache.delete key
-        elsif @cache.respond_to? :unset
-          @cache.unset key
-        else
-          raise NoMethodError, 'Cache should respond to :delete or :unset'
-        end
+      def cacheable(expires_in)
+        expires_in.nil? || expires_in.positive?
       end
 
       def key(action)
-        # Guard against caching unsupported actions.
-        raise ArgumentError, 'Action must be show' unless action.is_a?(::Jahuty::Action::Show)
+        # We only build cache keys for show-render actions at this time.
+        unless action.is_a?(::Jahuty::Action::Show) && action.resource == 'render'
+          raise ArgumentError, 'Action must be show render'
+        end
 
         fingerprint = Digest::MD5.new
         fingerprint << "snippets/#{action.id}/render/"
         fingerprint << action.params.to_json
 
         "jahuty_#{fingerprint.hexdigest}"
-      end
-
-      def read(key)
-        if @cache.respond_to? :read
-          @cache.read key
-        elsif @cache.respond_to? :get
-          @cache.get key
-        else
-          raise NoMethodError, 'Cache should respond to :read or :get'
-        end
-      end
-
-      def write(key, value, expires_in:)
-        if Object.const_defined?('::ActiveSupport::Cache::Store') &&
-           @cache.is_a?(::ActiveSupport::Cache::Store)
-          # Setting :race_condition_ttl is very useful in situations where a
-          # cache entry is used very frequently and is under heavy load.
-          #
-          # @see  https://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html#method-i-fetch
-          @cache.write key, value, expires_in: expires_in, race_condition_ttl: 10
-        elsif @cache.respond_to? :write
-          @cache.write key, value, expires_in: expires_in
-        elsif @cache.respond_to? :set
-          @cache.set key, value, expires_in: expires_in
-        else
-          raise NoMethodError, 'Cache should respond to :write or :set'
-        end
       end
     end
   end

--- a/lib/jahuty/cache/manager.rb
+++ b/lib/jahuty/cache/manager.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Jahuty
+  module Cache
+    # Fetches requested actions from the cache or the API.
+    class Manager
+      def initialize(cache:, client:, expires_in: nil)
+        @client     = client
+        @cache      = cache
+        @expires_in = expires_in
+      end
+
+      def fetch(action, expires_in: nil)
+        key = cache_key(action)
+
+        value = @cache.read(key)
+
+        if value.nil?
+          value = @client.request(action)
+          expires_in ||= @expires_in
+          @cache.write(key, value, expires_in: expires_in, race_condition_ttl: 10)
+        end
+
+        value
+      end
+
+      private
+
+      def cache_key(action)
+        # Guard against caching unsupported actions.
+        raise ArgumentError, 'Action must be show' unless action.is_a?(::Jahuty::Action::Show)
+
+        fingerprint = Digest::MD5.new
+        fingerprint << "snippets/#{action.id}/render/"
+        fingerprint << action.params.to_json
+
+        "jahuty_#{fingerprint.hexdigest}"
+      end
+    end
+  end
+end

--- a/lib/jahuty/cache/manager.rb
+++ b/lib/jahuty/cache/manager.rb
@@ -2,7 +2,8 @@
 
 module Jahuty
   module Cache
-    # Fetches requested actions from the cache or the API.
+    # Abstracts away differences between cache implementations and fetches the
+    # requested action from the cache or API.
     class Manager
       def initialize(cache:, client:, expires_in: nil)
         @client     = client
@@ -11,14 +12,12 @@ module Jahuty
       end
 
       def fetch(action, expires_in: nil)
-        key = cache_key(action)
-
-        value = @cache.read(key)
+        key   = key action
+        value = read key
 
         if value.nil?
-          value = @client.request(action)
-          expires_in ||= @expires_in
-          @cache.write(key, value, expires_in: expires_in, race_condition_ttl: 10)
+          value = @client.request action
+          write key, value, expires_in: expires_in || @expires_in
         end
 
         value
@@ -26,7 +25,7 @@ module Jahuty
 
       private
 
-      def cache_key(action)
+      def key(action)
         # Guard against caching unsupported actions.
         raise ArgumentError, 'Action must be show' unless action.is_a?(::Jahuty::Action::Show)
 
@@ -35,6 +34,33 @@ module Jahuty
         fingerprint << action.params.to_json
 
         "jahuty_#{fingerprint.hexdigest}"
+      end
+
+      def read(key)
+        if @cache.respond_to?(:read)
+          @cache.read(key)
+        elsif @cache.respond_to?(:get)
+          @cache.get(key)
+        else
+          raise ArgumentError, 'Cache not supported'
+        end
+      end
+
+      def write(key, value, expires_in:)
+        if Object.const_defined?('::ActiveSupport::Cache::Store') &&
+           @cache.is_a?(::ActiveSupport::Cache::Store)
+          # Setting :race_condition_ttl is very useful in situations where a
+          # cache entry is used very frequently and is under heavy load.
+          #
+          # @see  https://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html#method-i-fetch
+          @cache.write(key, value, expires_in: expires_in, race_condition_ttl: 10)
+        elsif @cache.respond_to?(:write)
+          @cache.write(key, value, expires_in: expires_in)
+        elsif @cache.respond_to?(:set)
+          @cache.set(key, value, expires_in: expires_in)
+        else
+          raise ArgumentError, 'Cache not supported'
+        end
       end
     end
   end

--- a/lib/jahuty/resource/render.rb
+++ b/lib/jahuty/resource/render.rb
@@ -2,9 +2,7 @@
 
 module Jahuty
   module Resource
-    # A snippet's rendered content. Remember, renders are unique by the
-    # combination of id and params (i.e., the same id can produce different
-    # renders with different params).
+    # A snippet's rendered content.
     class Render
       attr_accessor :content
 

--- a/lib/jahuty/service/snippet.rb
+++ b/lib/jahuty/service/snippet.rb
@@ -4,16 +4,12 @@ module Jahuty
   module Service
     # A service for interacting with snippets.
     class Snippet < Base
-      def render(id, options = {})
-        params = { params: options[:params].to_json } unless options[:params].nil?
+      def render(id, params: {}, expires_in: nil)
+        params = { params: params.to_json } unless params.empty?
 
-        action = ::Jahuty::Action::Show.new(
-          id: id,
-          resource: 'render',
-          params: params || {}
-        )
+        action = ::Jahuty::Action::Show.new(id: id, resource: 'render', params: params)
 
-        @client.request(action)
+        @client.fetch action, expires_in: expires_in
       end
     end
   end

--- a/lib/jahuty/version.rb
+++ b/lib/jahuty/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Jahuty
-  VERSION = '3.0.0'
+  VERSION = '3.1.0'
 end

--- a/spec/jahuty/cache/facade_spec.rb
+++ b/spec/jahuty/cache/facade_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+# context 'when the cache is not supported' do
+#   # Any object which doesn't respond to get/set or read/write will do.
+#   let(:cache)  { Object.new }
+#   let(:client) { instance_double(Jahuty::Client) }
+#
+#   it 'raises error' do
+#     expect { manager.fetch action }.to raise_error(NoMethodError)
+#   end
+# end
+
+module Jahuty
+  module Cache
+    # A concrete cache implementation for doubles.
+    class Cache
+      def read(key); end
+
+      def write(key, value, options = nil); end
+
+      def delete(key); end
+    end
+
+    RSpec.describe Facade do
+      subject(:facade) { described_class.new(cache) }
+
+      describe '#delete' do
+        context 'when the implementation is not supported' do
+          let(:cache) { Object.new }
+
+          it 'raises error' do
+            expect { facade.delete 'foo' }.to raise_error(NoMethodError)
+          end
+        end
+
+        context 'when the implementation is supported' do
+          let(:cache) do
+            cache = instance_double(Cache)
+            allow(cache).to receive(:delete)
+
+            cache
+          end
+
+          before { facade.delete 'foo' }
+
+          it 'calls delete' do
+            expect(cache).to have_received(:delete).with('foo')
+          end
+        end
+      end
+
+      describe '#read' do
+        context 'when the implementation is not supported' do
+          let(:cache) { Object.new }
+
+          it 'raises error' do
+            expect { facade.read 'foo' }.to raise_error(NoMethodError)
+          end
+        end
+
+        context 'when the implementation is supported' do
+          let(:cache) do
+            cache = instance_double(Cache)
+            allow(cache).to receive(:read)
+
+            cache
+          end
+
+          before { facade.read 'foo' }
+
+          it 'calls delete' do
+            expect(cache).to have_received(:read).with('foo')
+          end
+        end
+      end
+
+      describe '#write' do
+        context 'when the implementation is not supported' do
+          let(:cache) { Object.new }
+
+          it 'raises error' do
+            expect { facade.write 'foo', 'bar' }.to raise_error(NoMethodError)
+          end
+        end
+
+        context 'when the implementation is supported' do
+          let(:cache) do
+            cache = instance_double(Cache)
+            allow(cache).to receive(:write)
+
+            cache
+          end
+
+          before { facade.write 'foo', 'bar' }
+
+          it 'calls delete' do
+            expect(cache).to have_received(:write).with('foo', 'bar', expires_in: nil)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/jahuty/cache/manager_spec.rb
+++ b/spec/jahuty/cache/manager_spec.rb
@@ -101,6 +101,33 @@ module Jahuty
             expect(manager.fetch(action)).to be_instance_of(Jahuty::Resource::Render)
           end
         end
+
+        context 'when an :expires_in argument is passed' do
+          let(:expires_in) { 30 }
+
+          let(:cache) do
+            cache = instance_double(CacheImplementation)
+            allow(cache).to receive(:read).and_return(nil)
+            allow(cache).to receive(:write)
+
+            cache
+          end
+
+          let(:client) do
+            client = instance_double(Jahuty::Client)
+            allow(client).to receive(:request).and_return(render)
+
+            client
+          end
+
+          before { manager.fetch action, expires_in: expires_in }
+
+          it 'takes precedence' do
+            expect(cache).to have_received(:write).with(
+              anything, anything, hash_including(expires_in: expires_in)
+            )
+          end
+        end
       end
     end
   end

--- a/spec/jahuty/cache/manager_spec.rb
+++ b/spec/jahuty/cache/manager_spec.rb
@@ -2,8 +2,8 @@
 
 module Jahuty
   module Cache
-    # A cache implementation for doubles.
-    class CacheImplementation
+    # A concrete cache implementation for doubles.
+    class Cache
       def read(key); end
 
       def write(key, value, options = nil); end
@@ -20,7 +20,7 @@ module Jahuty
 
         context 'when the action is not supported' do
           let(:invalid_action) { instance_double(Jahuty::Action::Base) }
-          let(:cache)          { instance_double(CacheImplementation) }
+          let(:cache)          { instance_double(Cache) }
           let(:client)         { instance_double(Jahuty::Client) }
 
           it 'raises error' do
@@ -28,19 +28,9 @@ module Jahuty
           end
         end
 
-        context 'when the cache is not supported' do
-          # Any object which doesn't respond to get/set or read/write will do.
-          let(:cache)  { Object.new }
-          let(:client) { instance_double(Jahuty::Client) }
-
-          it 'raises error' do
-            expect { manager.fetch action }.to raise_error(NoMethodError)
-          end
-        end
-
         context 'when the action is cached' do
           let(:cache) do
-            cache = instance_double(CacheImplementation)
+            cache = instance_double(Cache)
             allow(cache).to receive(:read).and_return(render)
             allow(cache).to receive(:write)
 
@@ -73,7 +63,7 @@ module Jahuty
 
         context 'when the action is not cached' do
           let(:cache) do
-            cache = instance_double(CacheImplementation)
+            cache = instance_double(Cache)
             allow(cache).to receive(:read).and_return(nil)
             allow(cache).to receive(:write)
 
@@ -104,11 +94,11 @@ module Jahuty
           end
         end
 
-        context 'when an non-zero :expires_in argument is passed' do
+        context 'when a non-zero :expires_in argument is passed' do
           let(:expires_in) { 30 }
 
           let(:cache) do
-            cache = instance_double(CacheImplementation)
+            cache = instance_double(Cache)
             allow(cache).to receive(:read).and_return(nil)
             allow(cache).to receive(:write)
 
@@ -133,8 +123,8 @@ module Jahuty
 
         context 'when a zero :expires_in argument is passed' do
           let(:cache) do
-            cache = instance_double(CacheImplementation)
-            allow(cache).to receive(:read).and_return(nil)
+            cache = instance_double(Cache)
+            allow(cache).to receive(:read).and_return(render)
             allow(cache).to receive(:write)
             allow(cache).to receive(:delete)
 

--- a/spec/jahuty/cache/manager_spec.rb
+++ b/spec/jahuty/cache/manager_spec.rb
@@ -16,7 +16,27 @@ module Jahuty
         let(:render) { Jahuty::Resource::Render.new(content: 'foo') }
         let(:action) { Jahuty::Action::Show.new(resource: 'render', id: 1) }
 
-        context 'with a cache hit' do
+        context 'when the action is not supported' do
+          let(:invalid_action) { instance_double(Jahuty::Action::Base) }
+          let(:cache)          { instance_double(CacheImplementation) }
+          let(:client)         { instance_double(Jahuty::Client) }
+
+          it 'raises error' do
+            expect { manager.fetch invalid_action }.to raise_error(ArgumentError)
+          end
+        end
+
+        context 'when the cache is not supported' do
+          # Any object which doesn't respond to get/set or read/write will do.
+          let(:cache)  { Object.new }
+          let(:client) { instance_double(Jahuty::Client) }
+
+          it 'raises error' do
+            expect { manager.fetch action }.to raise_error(ArgumentError)
+          end
+        end
+
+        context 'when the action is cached' do
           let(:cache) do
             cache = instance_double(CacheImplementation)
             allow(cache).to receive(:read).and_return(render)
@@ -49,7 +69,7 @@ module Jahuty
           end
         end
 
-        context 'with a cache miss' do
+        context 'when the action is not cached' do
           let(:cache) do
             cache = instance_double(CacheImplementation)
             allow(cache).to receive(:read).and_return(nil)

--- a/spec/jahuty/cache/manager_spec.rb
+++ b/spec/jahuty/cache/manager_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module Jahuty
+  module Cache
+    # A cache implementation class for testing.
+    class CacheImplementation
+      def read(key); end
+
+      def write(key, value, options = nil); end
+    end
+
+    RSpec.describe Manager do
+      describe '#fetch' do
+        subject(:manager) { described_class.new(cache: cache, client: client) }
+
+        let(:render) { Jahuty::Resource::Render.new(content: 'foo') }
+        let(:action) { Jahuty::Action::Show.new(resource: 'render', id: 1) }
+
+        context 'with a cache hit' do
+          let(:cache) do
+            cache = instance_double(CacheImplementation)
+            allow(cache).to receive(:read).and_return(render)
+            allow(cache).to receive(:write)
+
+            cache
+          end
+
+          let(:client) do
+            client = instance_double(Jahuty::Client)
+            allow(client).to receive(:request)
+
+            client
+          end
+
+          it 'returns the cached value' do
+            expect(manager.fetch(action)).to eq(render)
+          end
+
+          it 'does not send API request' do
+            manager.fetch action
+
+            expect(client).not_to have_received(:request)
+          end
+
+          it 'does not cache value' do
+            manager.fetch action
+
+            expect(cache).not_to have_received(:write)
+          end
+        end
+
+        context 'with a cache miss' do
+          let(:cache) do
+            cache = instance_double(CacheImplementation)
+            allow(cache).to receive(:read).and_return(nil)
+            allow(cache).to receive(:write)
+
+            cache
+          end
+
+          let(:client) do
+            client = instance_double(Jahuty::Client)
+            allow(client).to receive(:request).and_return(render)
+
+            client
+          end
+
+          it 'sends API request' do
+            manager.fetch action
+
+            expect(client).to have_received(:request)
+          end
+
+          it 'caches the value' do
+            manager.fetch action
+
+            expect(cache).to have_received(:write)
+          end
+
+          it 'returns the value' do
+            expect(manager.fetch(action)).to be_instance_of(Jahuty::Resource::Render)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/jahuty/cache/manager_spec.rb
+++ b/spec/jahuty/cache/manager_spec.rb
@@ -2,7 +2,7 @@
 
 module Jahuty
   module Cache
-    # A cache implementation class for testing.
+    # A cache implementation for doubles.
     class CacheImplementation
       def read(key); end
 

--- a/spec/jahuty/client_spec.rb
+++ b/spec/jahuty/client_spec.rb
@@ -76,5 +76,18 @@ module Jahuty
         end
       end
     end
+
+    describe '#fetch' do
+      context 'when the action succeeds' do
+        before do
+          stub_request(:get, url)
+            .to_return(status: 200, body: '{"content":"foo"}', headers: {})
+        end
+
+        it 'returns render' do
+          expect(client.fetch(action)).to be_instance_of(Resource::Render)
+        end
+      end
+    end
   end
 end

--- a/spec/jahuty/client_system_spec.rb
+++ b/spec/jahuty/client_system_spec.rb
@@ -19,5 +19,23 @@ module Jahuty
         )
       end
     end
+
+    describe 'when snippet is requested many times' do
+      let(:client) do
+        described_class.new(
+          api_key: 'kn2Kj5ijmT2pH6ZKqAQyNexUqKeRM4VG6DDgWN1lIcc'
+        )
+      end
+
+      before { client.snippets.render 1 }
+
+      it 'uses cache' do
+        start1 = Time.now
+        client.snippets.render 1
+        end1 = Time.now
+
+        expect((end1 - start1) * 1000).to be < 1
+      end
+    end
   end
 end

--- a/spec/jahuty/resource/render_spec.rb
+++ b/spec/jahuty/resource/render_spec.rb
@@ -18,6 +18,16 @@ module Jahuty
           expect(render.to_s).to eq(content)
         end
       end
+
+      describe 'serialization' do
+        it 'does not raise error' do
+          expect { Marshal.load(Marshal.dump(render)) }.not_to raise_error(::TypeError)
+        end
+
+        it 'has correct attributes' do
+          expect(Marshal.load(Marshal.dump(render))).to have_attributes(content: 'foo')
+        end
+      end
     end
   end
 end

--- a/spec/jahuty/service/snippet_spec.rb
+++ b/spec/jahuty/service/snippet_spec.rb
@@ -11,7 +11,7 @@ module Jahuty
         let(:client) do
           client = instance_double('::Jahuty::Client')
 
-          allow(client).to receive(:request)
+          allow(client).to receive(:fetch)
 
           client
         end
@@ -22,8 +22,8 @@ module Jahuty
           it 'does not include params' do
             snippet.render(1)
 
-            expect(client).to have_received(:request)
-              .with(having_attributes(expected_attr))
+            expect(client).to have_received(:fetch)
+              .with(having_attributes(expected_attr), { expires_in: nil })
           end
         end
 
@@ -33,10 +33,10 @@ module Jahuty
           end
 
           it 'does include params' do
-            snippet.render(1, { params: { foo: 'bar' } })
+            snippet.render(1, params: { foo: 'bar' })
 
-            expect(client).to have_received(:request)
-              .with(having_attributes(expected_attr))
+            expect(client).to have_received(:fetch)
+              .with(having_attributes(expected_attr), { expires_in: nil })
           end
         end
       end


### PR DESCRIPTION
Add support for configuring a cache. 

- [x] Update the README.
- [x] Add examples to `Cache::Manager` if action or cache implementation is not supported.
- [x] Add examples to `Cache::Manager` to verify which `:expires_in` is used.
- [ ] Stage changes to docs.
- [x] Update manager to disable caching with a zero or negative integer `:expires_in`.

Closes #11 