### PR TITLE
Add support for unused attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.1.1 - 2020-02-26
+
+- Add support for extra, unused attributes returned by the API to support evolution.
+- Fix the `method redefined` warnings in `cache/manager_spec.rb` and `cache/facade_spec.rb`.
+- Fix the `expect { }.not_to raise_error(SpecificErrorClass)` false positives warnings in `resource/render_spec.rb`.
+
 ## 3.1.0 - 2020-01-04
 
 - Add caching support for any cache implementation that supports `get/set` or `read/write` methods.

--- a/lib/jahuty/resource/factory.rb
+++ b/lib/jahuty/resource/factory.rb
@@ -25,7 +25,7 @@ module Jahuty
 
         payload = parse(response)
 
-        Object.const_get(resource_class).send(:new, **payload)
+        Object.const_get(resource_class).send(:from, **payload)
       end
 
       private

--- a/lib/jahuty/resource/problem.rb
+++ b/lib/jahuty/resource/problem.rb
@@ -14,9 +14,9 @@ module Jahuty
       end
 
       def self.from(data)
-        raise ArgumentError.new "Key :status missing" if !data.key?(:status)
-        raise ArgumentError.new "Key :type missing" if !data.key?(:type)
-        raise ArgumentError.new "Key :detail missing" if !data.key?(:detail)
+        raise ArgumentError.new, 'Key :status missing' unless data.key?(:status)
+        raise ArgumentError.new, 'Key :type missing' unless data.key?(:type)
+        raise ArgumentError.new, 'Key :detail missing' unless data.key?(:detail)
 
         Problem.new(data.slice(:status, :type, :detail))
       end

--- a/lib/jahuty/resource/problem.rb
+++ b/lib/jahuty/resource/problem.rb
@@ -12,6 +12,14 @@ module Jahuty
         @type   = type
         @detail = detail
       end
+
+      def self.from(data)
+        raise ArgumentError.new "Key :status missing" if !data.key?(:status)
+        raise ArgumentError.new "Key :type missing" if !data.key?(:type)
+        raise ArgumentError.new "Key :detail missing" if !data.key?(:detail)
+
+        Problem.new(data.slice(:status, :type, :detail))
+      end
     end
   end
 end

--- a/lib/jahuty/resource/render.rb
+++ b/lib/jahuty/resource/render.rb
@@ -11,7 +11,7 @@ module Jahuty
       end
 
       def self.from(data)
-        raise ArgumentError.new "Key :content missing" if !data.key?(:content)
+        raise ArgumentError.new, 'Key :content missing' unless data.key?(:content)
 
         Render.new(data.slice(:content))
       end

--- a/lib/jahuty/resource/render.rb
+++ b/lib/jahuty/resource/render.rb
@@ -10,6 +10,12 @@ module Jahuty
         @content = content
       end
 
+      def self.from(data)
+        raise ArgumentError.new "Key :content missing" if !data.key?(:content)
+
+        Render.new(data.slice(:content))
+      end
+
       def to_s
         @content
       end

--- a/lib/jahuty/version.rb
+++ b/lib/jahuty/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Jahuty
-  VERSION = '3.1.0'
+  VERSION = '3.1.1'
 end

--- a/spec/jahuty/cache/facade_spec.rb
+++ b/spec/jahuty/cache/facade_spec.rb
@@ -1,15 +1,5 @@
 # frozen_string_literal: true
 
-# context 'when the cache is not supported' do
-#   # Any object which doesn't respond to get/set or read/write will do.
-#   let(:cache)  { Object.new }
-#   let(:client) { instance_double(Jahuty::Client) }
-#
-#   it 'raises error' do
-#     expect { manager.fetch action }.to raise_error(NoMethodError)
-#   end
-# end
-
 module Jahuty
   module Cache
     # A concrete cache implementation for doubles.

--- a/spec/jahuty/cache/manager_spec.rb
+++ b/spec/jahuty/cache/manager_spec.rb
@@ -2,15 +2,6 @@
 
 module Jahuty
   module Cache
-    # A concrete cache implementation for doubles.
-    class Cache
-      def read(key); end
-
-      def write(key, value, options = nil); end
-
-      def delete(key); end
-    end
-
     RSpec.describe Manager do
       describe '#fetch' do
         subject(:manager) { described_class.new(cache: cache, client: client) }
@@ -20,7 +11,7 @@ module Jahuty
 
         context 'when the action is not supported' do
           let(:invalid_action) { instance_double(Jahuty::Action::Base) }
-          let(:cache)          { instance_double(Cache) }
+          let(:cache)          { instance_double(Facade) }
           let(:client)         { instance_double(Jahuty::Client) }
 
           it 'raises error' do
@@ -30,7 +21,7 @@ module Jahuty
 
         context 'when the action is cached' do
           let(:cache) do
-            cache = instance_double(Cache)
+            cache = instance_double(Facade)
             allow(cache).to receive(:read).and_return(render)
             allow(cache).to receive(:write)
 
@@ -63,7 +54,7 @@ module Jahuty
 
         context 'when the action is not cached' do
           let(:cache) do
-            cache = instance_double(Cache)
+            cache = instance_double(Facade)
             allow(cache).to receive(:read).and_return(nil)
             allow(cache).to receive(:write)
 
@@ -98,7 +89,7 @@ module Jahuty
           let(:expires_in) { 30 }
 
           let(:cache) do
-            cache = instance_double(Cache)
+            cache = instance_double(Facade)
             allow(cache).to receive(:read).and_return(nil)
             allow(cache).to receive(:write)
 
@@ -123,7 +114,7 @@ module Jahuty
 
         context 'when a zero :expires_in argument is passed' do
           let(:cache) do
-            cache = instance_double(Cache)
+            cache = instance_double(Facade)
             allow(cache).to receive(:read).and_return(render)
             allow(cache).to receive(:write)
             allow(cache).to receive(:delete)

--- a/spec/jahuty/resource/problem_spec.rb
+++ b/spec/jahuty/resource/problem_spec.rb
@@ -31,25 +31,25 @@ module Jahuty
         it 'raises error if :status key does not exist' do
           data.delete(:status)
 
-          expect{ Problem.from(data) }.to raise_error(ArgumentError)
+          expect { described_class.from(data) }.to raise_error(ArgumentError)
         end
 
         it 'raises error if :type key does not exist' do
           data.delete(:type)
 
-          expect{ Problem.from(data) }.to raise_error(ArgumentError)
+          expect { described_class.from(data) }.to raise_error(ArgumentError)
         end
 
         it 'raises error if :detail key does not exist' do
           data.delete(:detail)
 
-          expect{ Problem.from(data) }.to raise_error(ArgumentError)
+          expect { described_class.from(data) }.to raise_error(ArgumentError)
         end
 
         it 'does not raise error if unused key exists' do
           data[:foo] = 'bar'
 
-          expect{ Problem.from(data) }.not_to raise_error
+          expect { described_class.from(data) }.not_to raise_error
         end
       end
     end

--- a/spec/jahuty/resource/problem_spec.rb
+++ b/spec/jahuty/resource/problem_spec.rb
@@ -24,6 +24,34 @@ module Jahuty
           expect(problem.detail).to eq(detail)
         end
       end
+
+      describe '::from' do
+        let(:data) { { status: 1, type: 'foo', detail: 'bar' } }
+
+        it 'raises error if :status key does not exist' do
+          data.delete(:status)
+
+          expect{ Problem.from(data) }.to raise_error(ArgumentError)
+        end
+
+        it 'raises error if :type key does not exist' do
+          data.delete(:type)
+
+          expect{ Problem.from(data) }.to raise_error(ArgumentError)
+        end
+
+        it 'raises error if :detail key does not exist' do
+          data.delete(:detail)
+
+          expect{ Problem.from(data) }.to raise_error(ArgumentError)
+        end
+
+        it 'does not raise error if unused key exists' do
+          data[:foo] = 'bar'
+
+          expect{ Problem.from(data) }.not_to raise_error
+        end
+      end
     end
   end
 end

--- a/spec/jahuty/resource/render_spec.rb
+++ b/spec/jahuty/resource/render_spec.rb
@@ -35,13 +35,13 @@ module Jahuty
         it 'raises error if :content key does not exist' do
           data.delete(:content)
 
-          expect{ Render.from(data) }.to raise_error(ArgumentError)
+          expect { described_class.from(data) }.to raise_error(ArgumentError)
         end
 
         it 'does not raise error if unused key exists' do
           data[:foo] = 'bar'
 
-          expect{ Render.from(data) }.not_to raise_error
+          expect { described_class.from(data) }.not_to raise_error
         end
       end
     end

--- a/spec/jahuty/resource/render_spec.rb
+++ b/spec/jahuty/resource/render_spec.rb
@@ -21,11 +21,27 @@ module Jahuty
 
       describe 'serialization' do
         it 'does not raise error' do
-          expect { Marshal.load(Marshal.dump(render)) }.not_to raise_error(::TypeError)
+          expect { Marshal.load(Marshal.dump(render)) }.not_to raise_error
         end
 
         it 'has correct attributes' do
           expect(Marshal.load(Marshal.dump(render))).to have_attributes(content: 'foo')
+        end
+      end
+
+      describe '::from' do
+        let(:data) { { content: 'foo' } }
+
+        it 'raises error if :content key does not exist' do
+          data.delete(:content)
+
+          expect{ Render.from(data) }.to raise_error(ArgumentError)
+        end
+
+        it 'does not raise error if unused key exists' do
+          data[:foo] = 'bar'
+
+          expect{ Render.from(data) }.not_to raise_error
         end
       end
     end


### PR DESCRIPTION
If we're going to evolve the API (e.g., add a `snippet_id` attribute to the `render` endpoint), our SDKs need to be able to silently ignore attributes they don't know what to do with yet. In the last major update, I got cute with keyword arguments, and I piped the parsed JSON response straight to the `initialize` method. This breaks if the response includes extra unused attributes. Let's fix that bug in preparation for adding collections. I also cleaned up warnings in the specs.