### PR TITLE
Add prefer latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.3.0 - 2020-04-29
+
+- Add the `prefer_latest` configuration option to the client and render methods. This setting allows you to render a snippet's _latest_ content instead of the default _published_ content.
+
 ## 3.2.1 - 2020-03-16
 
 * Fix issue with double-enveloping the `params` query string parameter.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It is multi-platform, and we strive to make it run equally well on Windows, Linu
 To install, add this line to your application's `Gemfile` and run `bundle install`:
 
 ```ruby
-gem 'jahuty', '~> 3.2'
+gem 'jahuty', '~> 3.3'
 ```
 
 ## Usage
@@ -64,9 +64,35 @@ renders = jahuty.snippets.all_renders 'YOUR_TAG'
 renders.each { |render| puts render }
 ```
 
-## Parameters
+## Rendering content
 
-You can [pass parameters](https://docs.jahuty.com/liquid/parameters) into your renders using the `params` option:
+You can use the `prefer_latest` configuration option to render a snippet's _latest_ content to your team in _development_ and its _published_ content to your customers in _production_.
+
+By default, Jahuty will render a snippet's _published_ content, the content that existed the last time someone clicked the "Publish" button, to avoid exposing your creative process to customers.
+
+To render a snippet's _latest_ content, the content that currently exists in the editor, you can use the `prefer_latest` configuration option at the library or render level:
+
+```ruby
+jahuty = Jahuty::Client.new api_key: 'YOUR_API_KEY', prefer_latest: true
+```
+
+You can also prefer the latest content (or not) for a single render:
+
+```ruby
+# Render the _published_ content for all snippets...
+jahuty = Jahuty::Client.new api_key: 'YOUR_API_KEY'
+
+# ... except, render the _latest_ content for this one.
+jahuty.snippets.render YOUR_SNIPPET_ID, prefer_latest: true
+```
+
+## Passing dynamic parameters
+
+You can use the _same_ snippet to generate _different_ content by defining [variables](https://docs.jahuty.com/liquid/variables) in your snippets and setting their values via [parameters](https://docs.jahuty.com/liquid/parameters).
+
+### Snippet parameters
+
+Use the `params` option to pass parameters into your snippet:
 
 ```ruby
 jahuty = Jahuty::Client.new(api_key: 'YOUR_API_KEY')
@@ -74,11 +100,15 @@ jahuty = Jahuty::Client.new(api_key: 'YOUR_API_KEY')
 jahuty.snippets.render YOUR_SNIPPET_ID, params: { foo: 'bar' }
 ```
 
-The parameters above would be equivalent to [assigning the variable](https://docs.jahuty.com/liquid/variables) below in your snippet:
+The parameters above would be equivalent to assigning the following variable in your snippet:
 
 ```html
 {% assign foo = "bar" %}
 ```
+
+### Collection parameters
+
+Collection parameters use a slightly different syntax.
 
 If you're rendering a collection, the first dimension of the `params` key determines the parameters' scope. Use an asterisk key (`*`) to pass the same parameters to all snippets, or use a snippet id as key to pass parameters to a specific snippet.
 
@@ -104,7 +134,7 @@ jahuty.snippets.all_renders 'YOUR_TAG', params: {
 }
 ```
 
-## Caching
+## Caching for performance
 
 You can use caching to control how frequently this library requests the latest content from Jahuty's API.
 
@@ -218,7 +248,7 @@ jahuty2 = Jahuty::Client.new(api_key: 'YOUR_API_KEY', expires_in: 60)
 jahuty2.snippets.render 1, expires_in: 0
 ```
 
-## Errors
+## Handling errors
 
 If an error occurs with [Jahuty's API](https://docs.jahuty.com/api#errors), a `Jahuty::Exception::Error` will be raised:
 

--- a/lib/jahuty/client.rb
+++ b/lib/jahuty/client.rb
@@ -5,11 +5,12 @@ require 'mini_cache'
 module Jahuty
   # Executes requests against Jahuty's API and returns resources.
   class Client
-    def initialize(api_key:, cache: nil, expires_in: nil)
-      @api_key    = api_key
-      @cache      = Cache::Facade.new(cache || ::MiniCache::Store.new)
+    def initialize(api_key:, cache: nil, expires_in: nil, prefer_latest: false)
+      @api_key = api_key
+      @cache = Cache::Facade.new(cache || ::MiniCache::Store.new)
       @expires_in = expires_in
-      @services   = {}
+      @services = {}
+      @prefer_latest = prefer_latest
     end
 
     # Allows services to be accessed as properties (e.g., jahuty.snippets).
@@ -17,7 +18,7 @@ module Jahuty
       if args.empty? && name == :snippets
         unless @services.key?(name)
           @services[name] = Service::Snippet.new(
-            client: self, cache: @cache, expires_in: @expires_in
+            client: self, cache: @cache, expires_in: @expires_in, prefer_latest: @prefer_latest
           )
         end
         @services[name]

--- a/lib/jahuty/response/handler.rb
+++ b/lib/jahuty/response/handler.rb
@@ -13,9 +13,9 @@ module Jahuty
 
         @resources ||= ::Jahuty::Resource::Factory.new
 
-        if collection?(action, payload)
+        if collection?(payload)
           payload.map { |data| @resources.call resource_name, data }
-        elsif resource?(action, payload)
+        elsif resource?(payload)
           @resources.call resource_name, payload
         else
           raise ArgumentError, 'Action and payload mismatch'
@@ -24,7 +24,7 @@ module Jahuty
 
       private
 
-      def collection?(action, payload)
+      def collection?(payload)
         payload.is_a?(::Array)
       end
 
@@ -47,7 +47,7 @@ module Jahuty
           (response.status < 200 || response.status >= 300)
       end
 
-      def resource?(action, payload)
+      def resource?(payload)
         payload.is_a?(::Object)
       end
 

--- a/lib/jahuty/response/handler.rb
+++ b/lib/jahuty/response/handler.rb
@@ -25,7 +25,7 @@ module Jahuty
       private
 
       def collection?(action, payload)
-        action.is_a?(Action::Index) && payload.is_a?(::Array)
+        payload.is_a?(::Array)
       end
 
       def name_resource(action, response)
@@ -48,7 +48,7 @@ module Jahuty
       end
 
       def resource?(action, payload)
-        !action.is_a?(Action::Index) && payload.is_a?(::Object)
+        payload.is_a?(::Object)
       end
 
       def success?(response)

--- a/lib/jahuty/service/snippet.rb
+++ b/lib/jahuty/service/snippet.rb
@@ -4,14 +4,15 @@ module Jahuty
   module Service
     # A service for interacting with snippets.
     class Snippet < Base
-      def initialize(client:, cache:, expires_in: nil)
+      def initialize(client:, cache:, expires_in: nil, prefer_latest: false)
         super(client: client)
 
         @cache = cache
         @expires_in = expires_in
+        @prefer_latest = prefer_latest
       end
 
-      def all_renders(tag, params: {}, expires_in: nil, prefer_latest: false)
+      def all_renders(tag, params: {}, expires_in: @expires_in, prefer_latest: @prefer_latest)
         renders = index_renders tag: tag, params: params, prefer_latest: prefer_latest
 
         cache_renders renders: renders, params: params, expires_in: expires_in
@@ -19,9 +20,7 @@ module Jahuty
         renders
       end
 
-      def render(snippet_id, params: {}, expires_in: nil, prefer_latest: false)
-        expires_in ||= @expires_in
-
+      def render(snippet_id, params: {}, expires_in: @expires_in, prefer_latest: @prefer_latest)
         key = cache_key snippet_id: snippet_id, params: params
 
         render = @cache.read(key)

--- a/lib/jahuty/service/snippet.rb
+++ b/lib/jahuty/service/snippet.rb
@@ -11,15 +11,15 @@ module Jahuty
         @expires_in = expires_in
       end
 
-      def all_renders(tag, params: {}, expires_in: nil)
-        renders = index_renders tag: tag, params: params
+      def all_renders(tag, params: {}, expires_in: nil, prefer_latest: false)
+        renders = index_renders tag: tag, params: params, prefer_latest: prefer_latest
 
         cache_renders renders: renders, params: params, expires_in: expires_in
 
         renders
       end
 
-      def render(snippet_id, params: {}, expires_in: nil)
+      def render(snippet_id, params: {}, expires_in: nil, prefer_latest: false)
         expires_in ||= @expires_in
 
         key = cache_key snippet_id: snippet_id, params: params
@@ -29,7 +29,7 @@ module Jahuty
         @cache.delete key unless render.nil? || cacheable?(expires_in)
 
         if render.nil?
-          render = show_render snippet_id: snippet_id, params: params
+          render = show_render snippet_id: snippet_id, params: params, prefer_latest: prefer_latest
 
           @cache.write key, render, expires_in: expires_in if cacheable?(expires_in)
         end
@@ -50,6 +50,8 @@ module Jahuty
       def cache_renders(renders:, params:, expires_in: nil)
         expires_in ||= @expires_in
 
+        return if renders.nil?
+
         return unless cacheable?(expires_in)
 
         global_params = params['*'] || {}
@@ -68,9 +70,10 @@ module Jahuty
         expires_in.nil? || expires_in.positive?
       end
 
-      def index_renders(tag:, params: {})
+      def index_renders(tag:, params: {}, prefer_latest: false)
         request_params = { tag: tag }
         request_params[:params] = params.to_json unless params.empty?
+        request_params[:latest] = 1 if prefer_latest
 
         action = ::Jahuty::Action::Index.new(
           resource: 'render',
@@ -80,9 +83,10 @@ module Jahuty
         @client.request action
       end
 
-      def show_render(snippet_id:, params: {})
+      def show_render(snippet_id:, params: {}, prefer_latest: false)
         request_params = {}
         request_params[:params] = params.to_json unless params.empty?
+        request_params[:latest] = 1 if prefer_latest
 
         action = ::Jahuty::Action::Show.new(
           id: snippet_id,

--- a/lib/jahuty/version.rb
+++ b/lib/jahuty/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Jahuty
-  VERSION = '3.2.1'
+  VERSION = '3.3.0'
 end

--- a/spec/jahuty/service/snippet_spec.rb
+++ b/spec/jahuty/service/snippet_spec.rb
@@ -84,6 +84,21 @@ module Jahuty
           end
         end
 
+        context 'with prefer_latest option' do
+          let(:expected_attr) do
+            { resource: 'render', params: { tag: 'foo', latest: 1 } }
+          end
+
+          before { allow(client).to receive(:request).and_return([]) }
+
+          it 'has latest' do
+            snippets.all_renders 'foo', prefer_latest: true
+
+            expect(client).to have_received(:request)
+              .with(having_attributes(expected_attr))
+          end
+        end
+
         context 'when a collection is returned' do
           before { allow(client).to receive(:request).and_return([render]) }
 
@@ -196,6 +211,19 @@ module Jahuty
 
           it 'does include params' do
             snippets.render 1, params: { foo: 'bar' }
+
+            expect(client).to have_received(:request)
+              .with(having_attributes(expected_attr))
+          end
+        end
+
+        context 'with prefer_latest option' do
+          let(:expected_attr) do
+            { id: 1, resource: 'render', params: { latest: 1 } }
+          end
+
+          it 'has latest' do
+            snippets.render 1, prefer_latest: true
 
             expect(client).to have_received(:request)
               .with(having_attributes(expected_attr))

--- a/spec/jahuty/system_spec.rb
+++ b/spec/jahuty/system_spec.rb
@@ -100,7 +100,7 @@ module Jahuty
       end
     end
 
-    describe '#all_renders' do
+    describe 'user renders many snippets' do
       context 'without parameters' do
         let(:renders) { jahuty.snippets.all_renders 'test' }
 

--- a/spec/jahuty/system_spec.rb
+++ b/spec/jahuty/system_spec.rb
@@ -152,7 +152,7 @@ module Jahuty
 
         it 'renders the snippet' do
           expect(render).to include(
-            an_object_having_attributes(content: '<p>This content is latest.</p>'),
+            an_object_having_attributes(content: '<p>This content is latest.</p>')
           )
         end
       end


### PR DESCRIPTION
Add the `prefer_latest` config option to  render a snippet's _latest_ content instead of its default _published_ content.