### PR TITLE
Ruby versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
                               --out test_results/rspec.xml \
                               --format progress \
                               $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
-  test-26:
+  test-30:
     docker:
       - image: cimg/ruby:3.0.2
     executor: ruby/default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,18 +3,42 @@ orbs:
   ruby: circleci/ruby@0.1.2
   codecov: codecov/codecov@1.1.3
 jobs:
-  build:
+  test-26:
     docker:
-      - image: circleci/ruby:2.6.3-stretch-node
+      - image: cimg/ruby:2.6.8
     executor: ruby/default
     steps:
       - checkout
+      - ruby/bundle-install
       - run:
-          name: Update bundler
-          command: gem install bundler
+          name: Run specs
+          command: |
+            bundle exec rspec --profile 10 \
+                              --format RspecJunitFormatter \
+                              --out test_results/rspec.xml \
+                              --format progress \
+                              $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
+  test-27:
+    docker:
+      - image: cimg/ruby:2.7.4
+    executor: ruby/default
+    steps:
+      - checkout
+      - ruby/bundle-install
       - run:
-          name: Which bundler?
-          command: bundle -v
+          name: Run specs
+          command: |
+            bundle exec rspec --profile 10 \
+                              --format RspecJunitFormatter \
+                              --out test_results/rspec.xml \
+                              --format progress \
+                              $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
+  test-26:
+    docker:
+      - image: cimg/ruby:3.0.2
+    executor: ruby/default
+    steps:
+      - checkout
       - ruby/bundle-install
       - run:
           name: Run rubocop
@@ -31,3 +55,11 @@ jobs:
           path: test_results
       - codecov/upload:
           file: ./coverage/coverage.xml
+
+workflows:
+  version: 2
+  test-ruby-versions:
+    jobs:
+      - test-26
+      - test-27
+      - test-30


### PR DESCRIPTION
Add builds for Ruby 2.6, 2.7, and 3.0 to build process. 

Also, I removed the install bundler and which bundler steps, since the new `cimg/ruby-X` images appear to have bundler already installed.

Closes #21 