### PR TITLE
Update gemspec for Ruby 3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 require:
  - rubocop-performance
  - rubocop-rspec
+ - rubocop-packaging
 AllCops:
   TargetRubyVersion: 2.6
   NewCops: enable

--- a/jahuty.gemspec
+++ b/jahuty.gemspec
@@ -4,7 +4,6 @@ lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'jahuty/version'
-require 'rake/file_list'
 
 Gem::Specification.new do |spec|
   spec.name          = 'jahuty'
@@ -23,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata['source_code_uri'] = 'https://github.com/jahuty/jahuty-ruby'
   spec.metadata['changelog_uri'] = 'https://github.com/jahuty/jahuty-ruby/blob/master/CHANGELOG.md'
 
-  spec.files         = Rake::FileList['**/*'].exclude(*File.read('.gitignore').split)
+  spec.files         = Dir['lib/**/*'] + %w[CHANGELOG.md LICENSE README.md]
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/jahuty.gemspec
+++ b/jahuty.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '~> 2.6'
+  spec.required_ruby_version = '>= 2.6'
 
   spec.add_dependency 'faraday', '~> 1.0'
   spec.add_dependency 'mini_cache', '~> 1.1'

--- a/jahuty.gemspec
+++ b/jahuty.gemspec
@@ -4,6 +4,7 @@ lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'jahuty/version'
+require 'rake/file_list'
 
 Gem::Specification.new do |spec|
   spec.name          = 'jahuty'
@@ -22,9 +23,7 @@ Gem::Specification.new do |spec|
   spec.metadata['source_code_uri'] = 'https://github.com/jahuty/jahuty-ruby'
   spec.metadata['changelog_uri'] = 'https://github.com/jahuty/jahuty-ruby/blob/master/CHANGELOG.md'
 
-  spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  end
+  spec.files         = Rake::FileList['**/*'].exclude(*File.read('.gitignore').split)
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
@@ -39,6 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec_junit_formatter', '~>0.4'
   spec.add_development_dependency 'rubocop', '~> 1.7'
+  spec.add_development_dependency 'rubocop-packaging', '~> 0.5'
   spec.add_development_dependency 'rubocop-performance', '~> 1.9'
   spec.add_development_dependency 'rubocop-rspec', '~> 2.1'
   spec.add_development_dependency 'simplecov', '~>0.20'

--- a/lib/jahuty/resource/problem.rb
+++ b/lib/jahuty/resource/problem.rb
@@ -18,7 +18,7 @@ module Jahuty
         raise ArgumentError.new, 'Key :type missing' unless data.key?(:type)
         raise ArgumentError.new, 'Key :detail missing' unless data.key?(:detail)
 
-        Problem.new(data.slice(:status, :type, :detail))
+        Problem.new(**data.slice(:status, :type, :detail))
       end
     end
   end

--- a/lib/jahuty/resource/render.rb
+++ b/lib/jahuty/resource/render.rb
@@ -15,7 +15,7 @@ module Jahuty
         raise ArgumentError.new, 'Key :content missing' unless data.key?(:content)
         raise ArgumentError.new, 'Key :snippet_id missing' unless data.key?(:snippet_id)
 
-        Render.new(data.slice(:content, :snippet_id))
+        Render.new(**data.slice(:content, :snippet_id))
       end
 
       def to_s

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,6 @@ SimpleCov.start
 require 'simplecov-cobertura'
 SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
 
-require 'bundler/setup'
 require 'jahuty'
 
 require 'webmock/rspec'


### PR DESCRIPTION
Update the package to support Ruby 3.

And, fix the issues with building multiple versions of Ruby. I changed the project configuration setting in CircleCi to build on every commit, not on a PR, because it didn't seem like CircleCI was detecting the newly opened PR.

I also added the [rubocop-packaging](https://github.com/utkarsh2102/rubocop-packaging). It suggested a change to the `gemspec` using `Rake::FileArray` instead of `git`, but I [used `Dir` instead](https://github.com/titusfortner/webdrivers/pull/185/files).

References #21 